### PR TITLE
fixed empty listToSort

### DIFF
--- a/list-ranker-final/src/sort-list.js
+++ b/list-ranker-final/src/sort-list.js
@@ -37,7 +37,7 @@ export default class SortList extends React.Component {
 	checkIfDisplay(alist) {
 		if (alist.length <= 0) {
             console.log("sorted" + sorted);
-            this.state.listToSort = sorted;
+            this.state.listToSort.push(...sorted);
             //this.setState({ listToSort: sorted });
             console.log("list to display" + this.state.listToSort);
 			this.props.displayFinal();


### PR DESCRIPTION
The original version overwrites the SortList variable instead of the App variable. You can use .push to manipulate the original list instead.